### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "version" : "0.2.1",
     "author" : "Wenzel P. P. Peppmeyer",
     "description" : "Render many pod6-files into one (big) html-file.",
-    "license" : "https://opensource.org/licenses/Artistic-2.0",
+    "license" : "Artistic-2.0",
     "provides" : {
         "Pod::To::BigPage" : "lib/Pod/To/BigPage.pm6"
     },


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license