### PR TITLE
Set default directory as "."

### DIFF
--- a/bin/pod2onepage
+++ b/bin/pod2onepage
@@ -17,7 +17,7 @@ sub next-part-index () {
     $clone
 }
 
-sub MAIN (Bool :v(:verbose($v)), Str :$source-path, Str :$exclude, Bool :$no-cache = False,
+sub MAIN (Bool :v(:verbose($v)), Str :$source-path = ".", Str :$exclude, Bool :$no-cache = False,
           Int :$threads = %*ENV<THREADS>.?Int // 1,
           Str :$precomp-path = (%*ENV<TEMP> // %*ENV<TMP> // '/tmp') ~ '/PodToBigfile-precomp' 
 ) {


### PR DESCRIPTION
Otherwise since it is not a required parameter, we fail part way
through the bulid process:

Cannot resolve caller dir(IO::Path: ); none of these signatures match:
    (IO::Path:D $: Mu :$test = { ... }, :$absolute, :$Str, :$CWD = { ... }, *%_)
  in block <unit> at

Note: Alternatively you could **require** a path by using `Str :$source-path!`
or even better: `Str:D :$source-path!`.